### PR TITLE
uint8_t

### DIFF
--- a/include/stc.hpp
+++ b/include/stc.hpp
@@ -36,8 +36,8 @@ inline int _get_color_mode_index() {
 
 class _color_data {
 public:
-  unsigned int r : 8, g : 8, b : 8, code : 8;
-  constexpr _color_data(int r, int g, int b, int code)
+  std::uint8_t r, g, b, code;
+  constexpr _color_data(std::uint8_t r, std::uint8_t g, std::uint8_t b, std::uint8_t code)
       : r(r), g(g), b(b), code(code){};
 };
 
@@ -50,10 +50,12 @@ inline std::ostream &operator<<(std::ostream &os,
                                 const _color_code<true> &color_code) {
   const long mode = os.iword(_get_color_mode_index());
   if (mode == _color_modes::COLOR_256)
-    os << "\033[38;5;" << color_code.code << 'm';
+    os << "\033[38;5;" << (int)color_code.code << 'm';
   else if (mode == _color_modes::TRUE_COLOR)
-    os << "\033[38;2;" << color_code.r << ';' << color_code.g << ';'
-       << color_code.b << 'm';
+    os << "\033[38;2;"
+       << (int)color_code.r << ';'
+       << (int)color_code.g << ';'
+       << (int)color_code.b << 'm';
   return os;
 }
 
@@ -62,10 +64,12 @@ inline std::ostream &operator<<(std::ostream &os,
                                 const _color_code<false> &color_code) {
   const long mode = os.iword(_get_color_mode_index());
   if (mode == _color_modes::COLOR_256)
-    os << "\033[48;5;" << color_code.code << 'm';
+    os << "\033[48;5;" << (int)color_code.code << 'm';
   else if (mode == _color_modes::TRUE_COLOR)
-    os << "\033[48;2;" << color_code.r << ';' << color_code.g << ';'
-       << color_code.b << 'm';
+    os << "\033[48;2;"
+       << (int)color_code.r << ';'
+       << (int)color_code.g << ';'
+       << (int)color_code.b << 'm';
   return os;
 }
 
@@ -340,7 +344,7 @@ constexpr float _color_distance(int r, int g, int b, _color_data color) {
           (blue_difference * blue_difference));
 }
 
-constexpr int _find_closest_color_code(int r, int g, int b) {
+constexpr std::uint8_t _find_closest_color_code(int r, int g, int b) {
   // for dark colors we return black, the cutoff values are arbitrary but
   // prevent artifacting from redmean color distance approximation
   if (r < 20 && g < 15 && b < 15)
@@ -446,26 +450,24 @@ inline std::ostream &reset_bg(std::ostream &os) {
 
 constexpr _color_code<true> rgb_fg(int r, int g, int b) {
   _clamp_rgb(r, g, b);
-  return {r, g, b, _find_closest_color_code(r, g, b)};
+  return {(std::uint8_t)r, (std::uint8_t)g, (std::uint8_t)b, _find_closest_color_code(r, g, b)};
 }
 
 constexpr _color_code<false> rgb_bg(int r, int g, int b) {
   _clamp_rgb(r, g, b);
-  return {r, g, b, _find_closest_color_code(r, g, b)};
+  return {(std::uint8_t)r, (std::uint8_t)g, (std::uint8_t)b, _find_closest_color_code(r, g, b)};
 }
 
 constexpr _color_code<true> hsl_fg(float h, float s, float l) {
   int r = 0, g = 0, b = 0;
   _hsl_to_rgb(h, s, l, r, g, b);
-  _clamp_rgb(r, g, b);
-  return {r, g, b, _find_closest_color_code(r, g, b)};
+  return {(std::uint8_t)r, (std::uint8_t)g, (std::uint8_t)b, _find_closest_color_code(r, g, b)};
 }
 
 constexpr _color_code<false> hsl_bg(float h, float s, float l) {
   int r = 0, g = 0, b = 0;
   _hsl_to_rgb(h, s, l, r, g, b);
-  _clamp_rgb(r, g, b);
-  return {r, g, b, _find_closest_color_code(r, g, b)};
+  return {(std::uint8_t)r, (std::uint8_t)g, (std::uint8_t)b, _find_closest_color_code(r, g, b)};
 }
 
 constexpr _color_code<true> code_fg(int code) {

--- a/include/stc.hpp
+++ b/include/stc.hpp
@@ -24,6 +24,7 @@ SOFTWARE.
 
 #pragma once
 #include <ostream>
+#include <cstdint>
 
 namespace stc {
 

--- a/include/stc.hpp
+++ b/include/stc.hpp
@@ -27,7 +27,7 @@ SOFTWARE.
 
 namespace stc {
 
-enum _color_modes { COLOR_256 = 0, TRUE_COLOR = 1, NO_COLOR = 2 };
+enum _color_modes : std::int8_t { COLOR_256 = 0, TRUE_COLOR = 1, NO_COLOR = 2 };
 
 inline int _get_color_mode_index() {
   static const int i = std::ios_base::xalloc();

--- a/include/stc.hpp
+++ b/include/stc.hpp
@@ -360,7 +360,7 @@ constexpr std::uint8_t _find_closest_color_code(int r, int g, int b) {
   return _256colors[best_index].code;
 }
 
-constexpr void _hsl_to_rgb(float h, float s, float l, int &r, int &g, int &b) {
+constexpr void _hsl_to_rgb(float h, float s, float l, std::uint8_t &r, std::uint8_t &g, std::uint8_t &b) {
   auto fmod = [](float number, int divisor) {
     const int i = (int)number;
     return (float)(i % divisor) + (number - (float)i);
@@ -374,7 +374,7 @@ constexpr void _hsl_to_rgb(float h, float s, float l, int &r, int &g, int &b) {
 
   // (https://en.wikipedia.org/wiki/HSL_and_HSV#Color_conversion_formulae)
   if (s == 0) {
-    r = g = b = round(l * 255);
+    r = g = b = (std::uint8_t)round(l * 255);
     return;
   }
   const float alpha = s * std::min(l, 1 - l);
@@ -382,9 +382,9 @@ constexpr void _hsl_to_rgb(float h, float s, float l, int &r, int &g, int &b) {
     const float k = fmod((n + (h * 12)), 12);
     return l - (alpha * std::max(-1.0F, std::min({k - 3, 9 - k, 1.0F})));
   };
-  r = round(f(0) * 255);
-  g = round(f(8) * 255);
-  b = round(f(4) * 255);
+  r = (std::uint8_t)round(f(0) * 255);
+  g = (std::uint8_t)round(f(8) * 255);
+  b = (std::uint8_t)round(f(4) * 255);
 }
 
 constexpr void _clamp(int &a, int min, int max) {
@@ -459,15 +459,15 @@ constexpr _color_code<false> rgb_bg(int r, int g, int b) {
 }
 
 constexpr _color_code<true> hsl_fg(float h, float s, float l) {
-  int r = 0, g = 0, b = 0;
+  std::uint8_t r = 0, g = 0, b = 0;
   _hsl_to_rgb(h, s, l, r, g, b);
-  return {(std::uint8_t)r, (std::uint8_t)g, (std::uint8_t)b, _find_closest_color_code(r, g, b)};
+  return {r, g, b, _find_closest_color_code(r, g, b)};
 }
 
 constexpr _color_code<false> hsl_bg(float h, float s, float l) {
-  int r = 0, g = 0, b = 0;
+  std::uint8_t r = 0, g = 0, b = 0;
   _hsl_to_rgb(h, s, l, r, g, b);
-  return {(std::uint8_t)r, (std::uint8_t)g, (std::uint8_t)b, _find_closest_color_code(r, g, b)};
+  return {r, g, b, _find_closest_color_code(r, g, b)};
 }
 
 constexpr _color_code<true> code_fg(int code) {

--- a/include/stc.hpp
+++ b/include/stc.hpp
@@ -25,6 +25,7 @@ SOFTWARE.
 #pragma once
 #include <ostream>
 #include <cstdint>
+#include <algorithm>
 
 namespace stc {
 


### PR DESCRIPTION
fixes C2398 and #2 issue
I would also like to include a header that defines std::size_t and replace all c-style casts with static_cast, but I'm not sure if this is appropriate.
it was also possible not to change _hsl_to_rgb, but to leave the usual c style cast.

